### PR TITLE
Fix module not being packaged

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     url="https://github.com/HuMoran/aapt",
     author="Tao.Hu",
     author_email="htax2013@gmail.com",
-    packages=find_packages(),
+    py_modules=['aapt'],
     include_package_data=True,
     platforms="any",
     install_requires=[],


### PR DESCRIPTION
When installing the package with pip, `aapt.py` is not installed.

```
>>> import aapt
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ModuleNotFoundError: No module named 'aapt'
```

The call to `find_packages()` in `setup.py` was returning an empty list. This PR fixes it by explicitely specifying the `aapt` module in the `py_modules` argument.